### PR TITLE
Signup sheet compiler uses directory contents to compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 ### TODOS
 
-* [ ] signupSheetCompiler - for not lasers (no need for special messages)
 * [ ] StatMunger - Categories are auto extracted from Category (LibCal direct download... do we need this?)
 * [ ] StatMunger - Headers for categories 1-4 are generated if they do not exist
-* [x] Signup lists are munged for printout
+* [x] signupSheetCompiler - autoselects files that are in a directory (typing?? gross.)
+* [x] signupSheetCompiler - for not lasers (no need for special messages)
+* [x] signupSheetCompiler - Signup lists are munged for printout
 
 ### Is LibCal making you super sads? Use this handy dandy tool to make your life a little less painful.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ### BUT HOW
 1. Clone (or fork and clone if you want to remix)
 1. Add your super awesome LibCal csv file(s) to the appropriate `./secretCSV/` directory
-1. Printing out signup sheets? Edit the `signupSheetCompiler.js` with the names of your sheets and run one of the following. Your compiled sheet will be named as is in the file with the suffix `-compiled` in the same directory as the first file in the list. List should be in order of time earliest to latest.
+1. Printing out signup sheets? Check the `signupSheetCompiler.js` to verify location of files and name of output file. List will print in order of file names.
     * `$ yarn signups`
     * `$ npm signups`
     * `$ node signupSheetCompiler.js`

--- a/signupSheetCompiler.js
+++ b/signupSheetCompiler.js
@@ -1,12 +1,16 @@
+const fs = require('fs');
+
 const signupSheetCompiler = require('./lib/signupSheetCompiler');
 
-// edit these below lines to point to all files you want to compile.
-// you can have one to many in this list, just copy the lines as is and edit.
+const directory = './secretCSV/signupSheets/'
+const nameOfOutputFile = "Today's signups"
 
-const signupSheets = [
-  './secretCSV/signupSheets/filename1.csv',
-  './secretCSV/signupSheets/filename2.csv',
-  './secretCSV/signupSheets/filename3.csv',
-  './secretCSV/signupSheets/filename4.csv',
-];
-signupSheetCompiler(signupSheets, "Today's lasers");
+fs.readdir(directory, function(err, directoryFiles) {
+  signupSheetCompiler((
+    directoryFiles.filter(file => {
+      return file.startsWith('lc_attendees')
+    }).map(file => {
+      return `${directory}${file}`
+    })
+  ), nameOfOutputFile);
+});


### PR DESCRIPTION
### What does this PR do?

Yay!!! No more hand typing of filenames! This PR just reads the contents of a directory for all `lc_attendees` files and creates a csv from these. Be sure to clear your contents! Although a file with a different day will throw an error, so you are p safe.

### How do I verify?

Dump some files in the `./secretCSV/signupSheets/` directory and run the script! So speedy!

### Any new dependencies?

Nerp, although there is some weirdness of some fs things happening in the script and some happening in the function.

### gif

![](https://media.giphy.com/media/l3mZfxgPWhmuXa8Cc/giphy.gif)